### PR TITLE
fix TagPileup tab-formatted output bug

### DIFF
--- a/src/scripts/Read_Analysis/TagPileup.java
+++ b/src/scripts/Read_Analysis/TagPileup.java
@@ -285,17 +285,20 @@ public class TagPileup extends JFrame {
 					if(STRAND == 0) tabbedPane_Scatterplot.add(BAM.getName(), CompositePlot.createCompositePlot(DOMAIN, AVG_S1, AVG_S2, BEDFiles.get(BED_Index).getName(), PARAM.getColors()));
 					else tabbedPane_Scatterplot.add(BAM.getName(), CompositePlot.createCompositePlot(DOMAIN, AVG_S1, BEDFiles.get(BED_Index).getName(), PARAM.getColors()));
 										
-					if(OUT_S1 != null && PARAM.getOutputType() == 2) {
-						if(PARAM.outputJTV()) {
+					if(OUT_S1 != null) {
+						if(PARAM.outputJTV() && PARAM.getOutputType() == 2) {
 							if(STRAND == 0) JTVOutput.outputJTV(PARAM.getOutput() + File.separator + generateFileName(BEDFiles.get(BED_Index).getName(), BAM.getName(), 0), PARAM.getSenseColor());
 							else JTVOutput.outputJTV(PARAM.getOutput() + File.separator + generateFileName(BEDFiles.get(BED_Index).getName(), BAM.getName(), 2), PARAM.getCombinedColor());
 						}
 						OUT_S1.close();
 					}
-					if(OUT_S2 != null && PARAM.getOutputType() == 2){
-						if(PARAM.outputJTV()) { JTVOutput.outputJTV(PARAM.getOutput() + File.separator + generateFileName(BEDFiles.get(BED_Index).getName(), BAM.getName(), 1), PARAM.getAntiColor()); }
+					if(OUT_S2 != null){
+						if(PARAM.outputJTV() && PARAM.getOutputType() == 2) {
+							JTVOutput.outputJTV(PARAM.getOutput() + File.separator + generateFileName(BEDFiles.get(BED_Index).getName(), BAM.getName(), 1), PARAM.getAntiColor());
+						}
 						OUT_S2.close();
 					}
+					
 					STATS.setCaretPosition(0);
 					JScrollPane newpane = new JScrollPane(STATS, JScrollPane.VERTICAL_SCROLLBAR_ALWAYS, JScrollPane.HORIZONTAL_SCROLLBAR_AS_NEEDED);
 					tabbedPane_Statistics.add(BAM.getName(), newpane);


### PR DESCRIPTION
This commit fixes the bug described in issue #41. The problem was in
the case of setting the output to be tab formatted, the Writer
objects OUT_S1 and/or OUT_S2 failed to close.

I adjusted the "if" statements for outputting JTV files (whose code
fell under the same conditionals as the code responsible for closing
the output Writer objects) so that they are consistent with previous
conditions but included the case of PARAM.getOutputType()==1 for
closing the Writer objects.