### PR TITLE
bugFix incorrectly load BED, not GFF

### DIFF
--- a/src/window_interface/Coordinate_Manipulation/GFF_Manipulation/SortGFFWindow.java
+++ b/src/window_interface/Coordinate_Manipulation/GFF_Manipulation/SortGFFWindow.java
@@ -279,7 +279,7 @@ public class SortGFFWindow extends JFrame implements ActionListener, PropertyCha
 		sl_contentPane.putConstraint(SpringLayout.NORTH, btnLoadGFFFile, 10, SpringLayout.NORTH, contentPane);
 		btnLoadGFFFile.addActionListener(new ActionListener() {
             public void actionPerformed(ActionEvent e) {
-				File newBEDFile = FileSelection.getFile(fc,"bed");
+				File newBEDFile = FileSelection.getFile(fc,"gff");
 				if(newBEDFile != null) {
 					GFF_File = newBEDFile;
 					lblGFFFile.setText(GFF_File.getName());


### PR DESCRIPTION
The extension for the files that the FileSelection object displayed was set to "bed", likely a copy-paste error from SortBEDWindow. This has been fixed to load GFF files.