### PR TITLE
hotfix v0.13 bug in 3 CoordMan tools

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ apply plugin: 'eclipse'
 
 sourceSets.main.java.srcDirs = ['src']
 mainClassName = "main.ScriptManager"
-version = 'v0.13-dev'
+version = 'v0.13'
 sourceCompatibility = 1.8
 targetCompatibility = 1.8
 

--- a/src/main/ScriptManager.java
+++ b/src/main/ScriptManager.java
@@ -70,7 +70,7 @@ import cli.Sequence_Analysis.SearchMotifCLI;
 			Read_AnalysisCLI.class,
 			Sequence_AnalysisCLI.class
 		},
-		version = "ScriptManager-v0.13-dev",
+		version = "ScriptManager-v0.13",
 		mixinStandardHelpOptions = true,
 		description = "Choose a tool directory from below to see more command-line tool options.",
 		exitCodeOnInvalidInput = 1,

--- a/src/main/ScriptManagerGUI.java
+++ b/src/main/ScriptManagerGUI.java
@@ -55,7 +55,7 @@ import window_interface.Figure_Generation.HeatMapWindow;
 import window_interface.Figure_Generation.MergeHeatMapWindow;
 
 public class ScriptManagerGUI {
-	public static final String VERSION = "0.13-dev";
+	public static final String VERSION = "0.13";
 
 	private JFrame frmScriptManager;	
 	/**

--- a/src/window_interface/Coordinate_Manipulation/BED_Manipulation/BEDtoGFFWindow.java
+++ b/src/window_interface/Coordinate_Manipulation/BED_Manipulation/BEDtoGFFWindow.java
@@ -62,7 +62,7 @@ public class BEDtoGFFWindow extends JFrame implements ActionListener, PropertyCh
         		if(OUTPUT_PATH == null) OUT_FILE = new File( gffName );
         		else OUT_FILE = new File( OUTPUT_PATH + File.separator + gffName );
         		// Execute conversion and update progress
-				BEDtoGFF.convertBEDtoGFF(OUTPUT_PATH, XBED);
+			BEDtoGFF.convertBEDtoGFF(OUT_FILE, XBED);
 				int percentComplete = (int)(((double)(x + 1) / BEDFiles.size()) * 100);
         		setProgress(percentComplete);
         	}

--- a/src/window_interface/Coordinate_Manipulation/GFF_Manipulation/ExpandGFFWindow.java
+++ b/src/window_interface/Coordinate_Manipulation/GFF_Manipulation/ExpandGFFWindow.java
@@ -76,8 +76,8 @@ public class ExpandGFFWindow extends JFrame implements ActionListener, PropertyC
 		        		File OUT_FILE = null;
 		        		if(OUTPUT_PATH == null) OUT_FILE = new File( newName );
 		        		else OUT_FILE = new File( OUTPUT_PATH + File.separator + newName );
-						// Execute expansion and update progress
-		        		ExpandGFF.expandGFFBorders(OUTPUT_PATH, XGFF, SIZE, rdbtnExpandFromCenter.isSelected());
+					// Execute expansion and update progress
+		        		ExpandGFF.expandGFFBorders(OUT_FILE, XGFF, SIZE, rdbtnExpandFromCenter.isSelected());
 						int percentComplete = (int)(((double)(x + 1) / GFFFiles.size()) * 100);
 		        		setProgress(percentComplete);
 		        	}

--- a/src/window_interface/Coordinate_Manipulation/GFF_Manipulation/GFFtoBEDWindow.java
+++ b/src/window_interface/Coordinate_Manipulation/GFF_Manipulation/GFFtoBEDWindow.java
@@ -62,7 +62,7 @@ public class GFFtoBEDWindow extends JFrame implements ActionListener, PropertyCh
 				if(OUTPUT_PATH == null) OUT_FILE = new File( bedName );
 				else OUT_FILE = new File( OUTPUT_PATH + File.separator + bedName );
 				// Execute conversion and update progress
-	    		GFFtoBED.convertGFFtoBED(OUTPUT_PATH, XGFF);
+	    		GFFtoBED.convertGFFtoBED(OUT_FILE, XGFF);
 				int percentComplete = (int)(((double)(x + 1) / BEDFiles.size()) * 100);
         		setProgress(percentComplete);
         	}


### PR DESCRIPTION
Output path directory, not file, given in three Coordinate Manipulation
tools in the GUI window_interface classes. CLI versions unaffected.

The recent release included a shift for the script classes to take the
output filename path instead of the output directory name path. The new
output filename was created within the window classes but the directory
name was passed instead for three of the Coordinate Manipulation group
window_interface classes. This commit both fixes this bug and renames
the JAR file, window title, and tool version for a new v0.13 release.