### PR TITLE
bugfix tagpileup was not outputting composite file

### DIFF
--- a/src/window_interface/Read_Analysis/TagPileupOutput.java
+++ b/src/window_interface/Read_Analysis/TagPileupOutput.java
@@ -27,14 +27,6 @@ public class TagPileupOutput extends JFrame {
 	
 	PileupParameters PARAM = null;
 	
-// 	private int STRAND = 0;
-// 	private int CPU = 1;
-	
-	PrintStream COMPOSITE = null;
-	// Generic print stream to accept PrintStream of GZIPOutputStream
-// 	Writer OUT_S1 = null;
-// 	Writer OUT_S2 = null;
-	
 	final JLayeredPane layeredPane;
 	final JTabbedPane tabbedPane;
 	final JTabbedPane tabbedPane_Scatterplot;
@@ -66,17 +58,9 @@ public class TagPileupOutput extends JFrame {
 		BEDFiles = be;
 		BAMFiles = ba;
 		PARAM = param;
-// 		STRAND = param.getStrand();
-// 		CPU = param.getCPU();
-		
 	}
 	
 	public void run() throws IOException {
-		if(PARAM.getOutputCompositeStatus()) {
-			try { COMPOSITE = new PrintStream(PARAM.getOutput() + File.separator + PARAM.getCompositeFile());
-			} catch (FileNotFoundException e) {	e.printStackTrace(); }
-		}
-		
 		//Check if BAI index file exists for all BAM files
 		boolean[] BAMvalid = new boolean[BAMFiles.size()];
 		for(int z = 0; z < BAMFiles.size(); z++) {

--- a/src/window_interface/Read_Analysis/TagPileupWindow.java
+++ b/src/window_interface/Read_Analysis/TagPileupWindow.java
@@ -49,7 +49,7 @@ public class TagPileupWindow extends JFrame implements ActionListener, PropertyC
 	Vector<File> BAMFiles = new Vector<File>();
 	final DefaultListModel<String> bedList;
 	Vector<File> BEDFiles = new Vector<File>();
-	private File OUTPUT = null;
+	private File OUTPUT = new File(System.getProperty("user.dir"));
 	
 	private JButton btnPileup;
 	private JButton btnLoadBamFiles;
@@ -163,7 +163,6 @@ public class TagPileupWindow extends JFrame implements ActionListener, PropertyC
 		        			        	
 		        	if(!chckbxOutputData.isSelected()) { param.setOutputType(0); }
 		        	if(!chckbxOutputData.isSelected() && !chckbxOutputCompositeData.isSelected()) {	param.setOutput(null); }
-		        	else if(OUTPUT == null) { param.setOutput(new File(System.getProperty("user.dir"))); }
 		        	else { param.setOutput(OUTPUT); }
 		        	
 		        	param.setOutputCompositeStatus(chckbxOutputCompositeData.isSelected()); //Outputs composite plots if check box is selected


### PR DESCRIPTION
Several exceptions were being thrown and the composite plot output file
was not being written. The two primary changes are elimination of unused
COMPOSITE variable in the TagPileupOutput class and the change of the
OUTPUT directory default in the TagPileupWindow class to be the user
directory that ScriptManager was executed from.