### PR TITLE
bugfix batch PEStat in GUI interface

### DIFF
--- a/src/scripts/BAM_Statistics/PEStats.java
+++ b/src/scripts/BAM_Statistics/PEStats.java
@@ -27,7 +27,6 @@ import charts.LineChart;
 public class PEStats {
 	
 	public static Vector<ChartPanel> getPEStats( File out_basename, File bamFile, boolean DUP_STATUS, int MIN_INSERT, int MAX_INSERT, PrintStream PS_INSERT, PrintStream PS_DUP, boolean SUM_STATUS ){
-		System.out.println("getPEStats called");
 		final SamReaderFactory factory = SamReaderFactory.makeDefault().enable(SamReaderFactory.Option.INCLUDE_SOURCE_IN_RECORDS, SamReaderFactory.Option.VALIDATE_CRC_CHECKSUMS).validationStringency(ValidationStringency.SILENT);
 		
 		// Output Vecotr of Charts to be returned
@@ -40,6 +39,7 @@ public class PEStats {
 		PrintStream OUT_DUP = null;
 		File OUT_DUPPNG = null;
 		
+		// Set output PrintStreams and PNG file objects
 		if( out_basename!=null ) {
 			try {
 				OUT_INSERT = new PrintStream(new File( out_basename.getCanonicalPath() + "_InsertHistogram.out"));
@@ -60,9 +60,7 @@ public class PEStats {
 		printBoth( null, OUT_INSERT_SUM, time );
 		printBoth( PS_INSERT, OUT_INSERT, time );
 		printBoth( PS_DUP, OUT_DUP, time );
-		
-		if(PS_DUP!=null){ PS_DUP.println("YO!"); }
-		
+
 		//Check if BAI index file exists
 		File f = new File(bamFile + ".bai");
 		if(f.exists() && !f.isDirectory()) {
@@ -77,6 +75,7 @@ public class PEStats {
 			//Code to get individual chromosome stats
 			SamReader reader = factory.open(bamFile);
 			AbstractBAMFileIndex bai = (AbstractBAMFileIndex) reader.indexing().getIndex();
+			System.out.println(bamFile);
 			
 			//Variables to keep track of insert size histogram
 			double InsertAverage = 0;
@@ -197,13 +196,13 @@ public class PEStats {
 			try{
 				charts.add( 0, Histogram.createBarChart(HIST, DOMAIN, OUT_INSPNG) );
 			}catch( IOException e ){ e.printStackTrace(); }
-			
+
+			//Duplication statistics
 			if(DUP_STATUS) {
-				//Duplication statistics
 				double UNIQUE_MOLECULES = 0;
 				String[] BIN_NAME = initializeBIN_Names();
 				ArrayList<Double> BIN = new ArrayList<Double>();
-				initializeBINS(BIN);	
+				initializeBINS(BIN);
 				
 				Iterator<Integer> keys = ALL_COMPLEXITY.keySet().iterator();
 				while(keys.hasNext()) {
@@ -223,14 +222,13 @@ public class PEStats {
 					charts.add( 1, LineChart.createLineChart(BIN, BIN_NAME, OUT_DUPPNG) );
 				}catch( IOException e ){ e.printStackTrace(); }
 			}
-			
 		} else {
+			charts.add(0, new ChartPanel(null));
+			charts.add(1, new ChartPanel(null));
 			printBoth( PS_INSERT, OUT_INSERT, "BAI Index File does not exist for: " + bamFile.getName() );
 			printBoth( System.err, OUT_INSERT_SUM, "BAI Index File does not exist for: " + bamFile.getName() );
 			printBoth( PS_DUP, OUT_DUP, "BAI Index File does not exist for: " + bamFile.getName() );
 		}
-		if(PS_INSERT != null){ PS_INSERT.close(); }
-		if(PS_DUP!=null){ PS_DUP.close(); }
 		
 		if(OUT_INSERT != null){ OUT_INSERT.close(); }
 		if(OUT_INSERT_SUM!=null){ OUT_INSERT_SUM.close(); }

--- a/src/window_interface/BAM_Statistics/PEStatOutput.java
+++ b/src/window_interface/BAM_Statistics/PEStatOutput.java
@@ -23,7 +23,7 @@ import scripts.BAM_Statistics.PEStats;
 public class PEStatOutput extends JFrame {
 	
 	Vector<File> bamFiles = null;
-	private File OUTPUT_PATH = null;
+	private File OUT_DIR = null;
 	private boolean OUTPUT_STATUS = false;
 	private boolean DUP_STATUS = false;
 	private static int MIN_INSERT = 0;
@@ -54,7 +54,7 @@ public class PEStatOutput extends JFrame {
 		layeredPane.add(tabbedPane);
 		
 		bamFiles = input;
-		OUTPUT_PATH = o;
+		OUT_DIR = o;
 		OUTPUT_STATUS = out;
 		DUP_STATUS = dup;
 		MIN_INSERT = min;
@@ -76,17 +76,17 @@ public class PEStatOutput extends JFrame {
 	public void run() throws IOException {
 		//Iterate through all BAM files in Vector	
 		for(int x = 0; x < bamFiles.size(); x++) {
-			
 			// Construct Basename
-			File NAME = null;
+			File OUT_BASENAME = null;
 			if(OUTPUT_STATUS){
 				try{
-					NAME = new File( bamFiles.get(x).getName().split("\\.")[0] );
-					if(OUTPUT_PATH != null){ NAME = new File( OUTPUT_PATH.getCanonicalPath() + File.separator + NAME.getCanonicalPath() ); }
+					if(OUT_DIR == null) { OUT_BASENAME = new File(bamFiles.get(x).getName().split("\\.")[0]); }
+					else { OUT_BASENAME = new File( OUT_DIR.getCanonicalPath() + File.separator + bamFiles.get(x).getName().split("\\.")[0] ); }
 				}
 				catch (FileNotFoundException e) { e.printStackTrace(); }
 // 				catch (IOException e) {	e.printStackTrace(); }
 			}
+			
 			// Initialize PrintStream and TextArea for PE stats (insert sizes)
 			PrintStream ps_insert = null;
 			JTextArea PE_STATS = new JTextArea();
@@ -99,9 +99,9 @@ public class PEStatOutput extends JFrame {
 				DUP_STATS.setEditable(false);
 				ps_dup = new PrintStream(new CustomOutputStream( DUP_STATS ));
 			}
-			
+
 			//Call public static method from scripts
-			Vector<ChartPanel> charts = PEStats.getPEStats( NAME, bamFiles.get(x), DUP_STATUS, MIN_INSERT, MAX_INSERT, ps_insert, ps_dup, false );
+			Vector<ChartPanel> charts = PEStats.getPEStats( OUT_BASENAME, bamFiles.get(x), DUP_STATUS, MIN_INSERT, MAX_INSERT, ps_insert, ps_dup, false );
 			
 			//Add pe stats to tabbed pane
 			PE_STATS.setCaretPosition(0);
@@ -117,7 +117,7 @@ public class PEStatOutput extends JFrame {
 				tabbedPane_Duplication.add(bamFiles.get(x).getName(), charts.get(1));
 			}
 			
-			ps_dup.close();
+			if(ps_dup!=null) { ps_dup.close(); }
 			ps_insert.close();
 			
 			firePropertyChange("bam",x, x + 1);	

--- a/src/window_interface/BAM_Statistics/PEStatWindow.java
+++ b/src/window_interface/BAM_Statistics/PEStatWindow.java
@@ -52,7 +52,7 @@ public class PEStatWindow extends JFrame implements ActionListener, PropertyChan
 	
 	final DefaultListModel<String> expList;
 	Vector<File> BAMFiles = new Vector<File>();
-	private File OUTPUT_PATH = null;
+	private File OUTPUT_PATH = new File(System.getProperty("user.dir"));
 	
 	JProgressBar progressBar;
 	public Task task;
@@ -72,7 +72,7 @@ public class PEStatWindow extends JFrame implements ActionListener, PropertyChan
 			        	setProgress(percentComplete);
 				     }
 				 });
-				stat.setVisible(true);				
+				stat.setVisible(true);
 				stat.run();
 			} catch(NumberFormatException nfe){
 				JOptionPane.showMessageDialog(null, "Input Fields Must Contain Integers");


### PR DESCRIPTION
This update fixes the GUI PEStat bugs that cause the PEStat tool to quit execution after the first BAM file has its stats calculated. It also fixes the GUI so that BAM files without BAI do not interrupt execution of a set of BAMs.